### PR TITLE
Tweaks to build and fixes to warnings generated by said tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lib/.deps/
 lib/.dirstamp
 lib/zopfli/.deps/
 lib/zopfli/.dirstamp
+lib/stamp-h1
 src/.deps/
 src/.dirstamp
 lib/time.h

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ autom4te.cache/
 m4/
 lib/libpigz.a
 *.tar.gz
+tags

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ pigz_SOURCES = \
 	       lib/zopfli/squeeze.c \
 	       lib/zopfli/squeeze.h \
 	       lib/zopfli/symbols.c \
-	       libzopfli/symbols.h \
+	       lib/zopfli/symbols.h \
 	       lib/zopfli/tree.c \
 	       lib/zopfli/tree.h \
 	       lib/zopfli/util.c \

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,6 +1,7 @@
 
 gnulib_modules="\
   pthread
+  manywarnings
 "
 
 buildreq="\

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AH_TEMPLATE([PIGZ_DEBUG],
 	    [Advanced debugging info such as memory use and very detailed logging.])
 AC_ARG_ENABLE([zopfli],
 	[AS_HELP_STRING([--disable-zopfli],
-		[Disable zopfli, a very slow but very effective algorithm])],
+		[Disable support for zopfli, a very slow but very effective algorithm])],
 	[AS_IF([test "x$enable_zopfli" == "xno"],
 	       AC_DEFINE([NOZOPFLI]))])
 dnl before you ask, I don't know why they would do the x thing. it's in the
@@ -39,6 +39,13 @@ AM_SILENT_RULES([yes])
 AC_PROG_CC_C99
 gl_EARLY
 gl_INIT
+gl_MANYWARN_ALL_GCC([warnings])
+dnl ignored warnings:
+nw=
+gl_MANYWARN_COMPLEMENT([warnings], [$warnings], [$nw])
+for w in $warnings; do
+	gl_WARN_ADD([$w])
+done
 AC_PROG_RANLIB
 LIBS="-lm -lpthread -lz"
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1,25 +1,32 @@
 AC_PREREQ([2.65])
-AC_INIT([pigz], m4_esyscmd_s(git describe))
+AC_INIT([pigz], m4_esyscmd_s([git describe --dirty]))
 AC_CONFIG_SRCDIR(src/pigz.c)
 AC_CONFIG_LIBOBJ_DIR([lib])
 
+AH_TEMPLATE([NOTHREAD],
+	    [Disable support for multithreading.])
+AH_TEMPLATE([NOZOPFLI],
+	    [Disable support for Google zopfli, a very effective but very
+	     slow compression algorithm.])
 AC_ARG_ENABLE([zopfli],
-	[AS_HELP_STRING([--enable-zopfli],
-		[Enable zopfli, a very slow but very effective algorithm (default yes)])],
+	[AS_HELP_STRING([--disable-zopfli],
+		[Disable zopfli, a very slow but very effective algorithm])],
 	[AS_IF([test "x$enable_zopfli" == "xno"],
 	       AC_DEFINE([NOZOPFLI]))])
 dnl before you ask, I don't know why they would do the x thing. it's in the
 dnl autoconf manual and I don't like to think about the many idiosyncrasies of sh.
 
 AC_ARG_ENABLE([threads],
-	[AS_HELP_STRING([--enable-threads],
-		[Enable speedup by multithreading (default yes)])],
+	[AS_HELP_STRING([--disable-threads],
+		[Disable speedup by multithreading])],
 	[AS_IF([test "x$enable_threads" == "xno"],
 	       AC_DEFINE([NOTHREAD]))])
 
 AC_CONFIG_FILES([Makefile lib/Makefile])
-AC_CONFIG_AUX_DIR([build-aux])
 
+
+AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_HEADERS([lib/config.h:lib/config.hin])
 AM_INIT_AUTOMAKE([1.11 foreign subdir-objects -Wall -Werror]) 
 dnl TODO: change to 'foreign'->'gnu' after adding requisite infos.
 AM_SILENT_RULES([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ AH_TEMPLATE([NOTHREAD],
 AH_TEMPLATE([NOZOPFLI],
 	    [Disable support for Google zopfli, a very effective but very
 	     slow compression algorithm.])
+AH_TEMPLATE([PIGZ_DEBUG],
+	    [Advanced debugging info such as memory use and very detailed logging.])
 AC_ARG_ENABLE([zopfli],
 	[AS_HELP_STRING([--disable-zopfli],
 		[Disable zopfli, a very slow but very effective algorithm])],
@@ -18,10 +20,14 @@ dnl autoconf manual and I don't like to think about the many idiosyncrasies of s
 
 AC_ARG_ENABLE([threads],
 	[AS_HELP_STRING([--disable-threads],
-		[Disable speedup by multithreading])],
+		[Disable speedup by multithreading.])],
 	[AS_IF([test "x$enable_threads" == "xno"],
 	       AC_DEFINE([NOTHREAD]))])
-
+AC_ARG_ENABLE([advanced-debug],
+	[AS_HELP_STRING([--enable-advanced-debug],
+		[Enable advanced verbose debugging.])],
+	[AS_IF([test "xenable_advanced_debug" != "xno"],
+	       AC_DEFINE([PIGZ_DEBUG]))])
 AC_CONFIG_FILES([Makefile lib/Makefile])
 
 

--- a/lib/try.h
+++ b/lib/try.h
@@ -250,7 +250,7 @@
 
 #ifndef _TRY_H
 #define _TRY_H
-
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/lib/zopfli/deflate.c
+++ b/lib/zopfli/deflate.c
@@ -431,7 +431,7 @@ Changes the population counts in a way that the consequent Huffman tree
 compression, especially its rle-part, will be more likely to compress this data
 more efficiently. length contains the size of the histogram.
 */
-void OptimizeHuffmanForRle(int length, size_t* counts) {
+void OptimizeHuffmanForRle(size_t length, size_t* counts) {
   int i, k, stride;
   size_t symbol, sum, limit;
   int* good_for_rle;

--- a/src/pigz.c
+++ b/src/pigz.c
@@ -320,6 +320,7 @@
  */
 
 // Use large file functions if available.
+#include <config.h>
 #define _FILE_OFFSET_BITS 64
 
 // Included headers and what is expected from each.

--- a/src/pigz.c
+++ b/src/pigz.c
@@ -3065,7 +3065,7 @@ local void show_info(int method, unsigned long check, length_t len, int cont) {
     if (cont)
         strncpy(tag, "<...>", max + 1);
     else if (g.hname == NULL) {
-        n = strlen(g.inf) - compressed_suffix(g.inf);
+        n = strnlen(g.inf, g.inz) - compressed_suffix(g.inf);
         strncpy(tag, g.inf, n > max + 1 ? max + 1 : n);
         if (strcmp(g.inf + n, ".tgz") == 0 && n < max + 1)
             strncpy(tag + n, ".tar", max + 1 - n);
@@ -3877,7 +3877,7 @@ local void process(char *path) {
         // set input file name (already set if recursed here)
         if (path != g.inf)
             vstrcpy(&g.inf, &g.inz, 0, path);
-        len = strlen(g.inf);
+        len = strnlen(g.inf, g.inz);
 
         // try to stat input file -- if not there and decoding, look for that
         // name with compressed suffixes
@@ -3901,7 +3901,7 @@ local void process(char *path) {
                 complain("skipping: %s does not exist", g.inf);
                 return;
             }
-            len = strlen(g.inf);
+            len = strnlen(g.inf, g.inz);
         }
 
         // only process regular files or named pipes, but allow symbolic links


### PR DESCRIPTION
Fixes:
* Typo causing distribution fail  
* Signed/unsigned issues in allocator function  
* Potential buffer overflow (`strlen`+`strcpy`)  

Tweaks:
* Ignore more annoying generated files  
* Use generated header instead of command line options for compile-time config  
* Make `./configure` help text more concise  
* Enable `manywarnings` library.