### PR TITLE
Fixes build error with xalloc-die module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,34 +1,37 @@
 SUBDIRS = lib
 
 bin_PROGRAMS = pigz
-pigz_LDADD = $(LIBOBJS)
+pigz_LDADD = $(LIBOBJS) $(LIBS) $(LIB_PTHREAD)
 pigz_SOURCES = \
-	       src/pigz.c \
-	       lib/try.c \
-	       lib/try.h \
-	       lib/yarn.c \
-	       lib/yarn.h \
-	       lib/zopfli/blocksplitter.c \
-	       lib/zopfli/blocksplitter.h \
-	       lib/zopfli/cache.c \
-	       lib/zopfli/cache.h \
-	       lib/zopfli/deflate.c \
-	       lib/zopfli/deflate.h \
-	       lib/zopfli/hash.c \
-	       lib/zopfli/hash.h \
-	       lib/zopfli/katajainen.c \
-	       lib/zopfli/katajainen.h \
-	       lib/zopfli/lz77.c \
-	       lib/zopfli/lz77.h \
-	       lib/zopfli/squeeze.c \
-	       lib/zopfli/squeeze.h \
-	       lib/zopfli/symbols.c \
-	       lib/zopfli/symbols.h \
-	       lib/zopfli/tree.c \
-	       lib/zopfli/tree.h \
-	       lib/zopfli/util.c \
-	       lib/zopfli/util.h \
-	       lib/zopfli/zopfli.h
+	src/pigz.c \
+	lib/try.c \
+       lib/try.h \
+       lib/yarn.c \
+       lib/yarn.h \
+       lib/zopfli/blocksplitter.c \
+       lib/zopfli/blocksplitter.h \
+       lib/zopfli/cache.c \
+       lib/zopfli/cache.h \
+       lib/zopfli/deflate.c \
+       lib/zopfli/deflate.h \
+       lib/zopfli/hash.c \
+       lib/zopfli/hash.h \
+       lib/zopfli/katajainen.c \
+       lib/zopfli/katajainen.h \
+       lib/zopfli/lz77.c \
+       lib/zopfli/lz77.h \
+       lib/zopfli/squeeze.c \
+       lib/zopfli/squeeze.h \
+       lib/zopfli/symbols.c \
+       lib/zopfli/symbols.h \
+       lib/zopfli/tree.c \
+       lib/zopfli/tree.h \
+       lib/zopfli/util.c \
+       lib/zopfli/util.h \
+       lib/zopfli/zopfli.h \
+       lib/xmalloc.c \
+       lib/xalloc-die.c \
+       lib/exitfail.c
 
 EXTRA_DIST = \
 	     lib/zopfli/README \

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,8 +1,9 @@
 
 gnulib_modules="\
+  stdlib
   pthread
   manywarnings
-  xalloc
+  xalloc-die
 "
 
 buildreq="\

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_PROG_CC_C99
 gl_EARLY
 gl_INIT
 gl_MANYWARN_ALL_GCC([warnings])
+gl_XALLOC
 dnl ignored warnings:
 nw=
 gl_MANYWARN_COMPLEMENT([warnings], [$warnings], [$nw])
@@ -47,5 +48,5 @@ for w in $warnings; do
 	gl_WARN_ADD([$w])
 done
 AC_PROG_RANLIB
-LIBS="-lm -lpthread -lz"
+LIBS="-lm -lz"
 AC_OUTPUT

--- a/src/pigz.c
+++ b/src/pigz.c
@@ -323,6 +323,7 @@
 #include <config.h>
 #define _FILE_OFFSET_BITS 64
 
+#include "xalloc.h"
 // Included headers and what is expected from each.
 #include <stdio.h>              // fflush(), fprintf(), fputs(), getchar(), putc(),
                         // puts(), printf(), vasprintf(), stderr, EOF, NULL,
@@ -349,7 +350,6 @@
                         // struct dirent
 #include <limits.h>             // UINT_MAX, INT_MAX
 
-#include <xalloc.h>
 
 #if __STDC_VERSION__-0 >= 199901L || __GNUC__-0 >= 3
 #include <inttypes.h>           // intmax_t, uintmax_t


### PR DESCRIPTION
Apparently you have to include and redistribute the things you get from gnulib manually. good thing this is mentioned anywhere at all in any documentation